### PR TITLE
Custom separator for decamelize and depascalize

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ pascalizeKeysInPlace(obj)
 // optionally modify the object in-place.
 depascalizeKeys(obj)
 depascalizeKeysInPlace(obj)
+
+// Optional custom separator for decamelizeKeys,
+// depascalizeKeys, and in-place variants.
+decamelizeKeys(obj, '-')
+decamelizeKeysInPlace(obj, '-')
+depascalizeKeys(obj, '-')
+depascalizeKeysInPlace(obj, '-')
 ```
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -36,11 +36,19 @@ camelize(string)
 // 'aString' -> 'a_string'
 decamelize(string)
 
+// Optional custom separator
+// 'aString' -> 'a-string'
+decamelize(string, '-')
+
 // 'a_string' -> 'AString'
 pascalize(string)
 
 // 'AString' -> 'a_string'
 depascalize(string)
+
+// Optional custom separator
+// 'AString' -> 'a-string'
+depascalize(string, '-')
 
 // Camelize all object keys (recursive),
 // optionally modify the object in-place.

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,7 +81,7 @@ export function decamelize(str: string, sep?: string) {
 
   let separator = CHAR_UNDERSCORE
 
-  if(sep && sep.charCodeAt(0)) {
+  if (sep && sep.charCodeAt(0)) {
     separator = sep.charCodeAt(0)
   }
 
@@ -155,7 +155,7 @@ export function depascalize(str: string, sep?: string) {
 
   let separator = CHAR_UNDERSCORE
 
-  if(sep && sep.charCodeAt(0)) {
+  if (sep && sep.charCodeAt(0)) {
     separator = sep.charCodeAt(0)
   }
 
@@ -178,19 +178,23 @@ function isObjectOrArray(value: unknown): value is ObjectOrArray {
   return Boolean(value) && typeof value === 'object' && !(value instanceof Function) && !(value instanceof Date)
 }
 
-function transformArray(array: Array<unknown>, transform: (key: string) => string) {
+function transformArray(array: Array<unknown>, transform: (key: string, sep?: string) => string, sep?: string) {
   const length = array.length
   const transformed = new Array(length)
   let idx = 0
   for (const item of array) {
-    transformed[idx++] = isObjectOrArray(item) ? transformKeys(item, transform) : item
+    transformed[idx++] = isObjectOrArray(item) ? transformKeys(item, transform, sep) : item
   }
   return transformed
 }
 
-function transformKeys(obj: ObjectOrArray | Array<unknown>, transform: (key: string) => string) {
+function transformKeys(
+  obj: ObjectOrArray | Array<unknown>,
+  transform: (key: string, sep?: string) => string,
+  sep?: string,
+) {
   if (Array.isArray(obj)) {
-    return transformArray(obj, transform)
+    return transformArray(obj, transform, sep)
   }
 
   if (typeof obj.prototype !== 'undefined') {
@@ -200,34 +204,34 @@ function transformKeys(obj: ObjectOrArray | Array<unknown>, transform: (key: str
   const transformed: Record<string, unknown> = {}
   for (const key in obj) {
     const value = obj[key]
-    const nextKey = transform(key)
-    transformed[nextKey] = isObjectOrArray(value) ? transformKeys(value, transform) : value
+    const nextKey = transform(key, sep)
+    transformed[nextKey] = isObjectOrArray(value) ? transformKeys(value, transform, sep) : value
   }
   return transformed
 }
 
-function transformArrayInPlace(array: Array<unknown>, transform: (key: string) => string) {
+function transformArrayInPlace(array: Array<unknown>, transform: (key: string, sep?: string) => string, sep?: string) {
   let idx = 0
   for (const item of array) {
-    array[idx++] = isObjectOrArray(item) ? transformKeysInPlace(item, transform) : item
+    array[idx++] = isObjectOrArray(item) ? transformKeysInPlace(item, transform, sep) : item
   }
   return array
 }
 
-function transformKeysInPlace(obj: ObjectOrArray, transform: (key: string) => string) {
+function transformKeysInPlace(obj: ObjectOrArray, transform: (key: string, sep?: string) => string, sep?: string) {
   if (Array.isArray(obj)) {
-    return transformArrayInPlace(obj, transform)
+    return transformArrayInPlace(obj, transform, sep)
   }
 
   for (const key in obj) {
     const value = obj[key]
-    const nextKey = transform(key)
+    const nextKey = transform(key, sep)
 
     if (nextKey !== key) {
       delete obj[key]
     }
 
-    obj[nextKey] = isObjectOrArray(value) ? transformKeysInPlace(value, transform) : value
+    obj[nextKey] = isObjectOrArray(value) ? transformKeysInPlace(value, transform, sep) : value
   }
 
   return obj
@@ -241,12 +245,12 @@ export function camelizeKeys(obj: ObjectOrArray) {
   return transformKeys(obj, camelize)
 }
 
-export function decamelizeKeys(obj: ObjectOrArray) {
+export function decamelizeKeys(obj: ObjectOrArray, sep?: string) {
   if (!isObjectOrArray(obj)) {
     return obj
   }
 
-  return transformKeys(obj, decamelize)
+  return transformKeys(obj, decamelize, sep)
 }
 
 export function pascalizeKeys(obj: ObjectOrArray) {
@@ -257,12 +261,12 @@ export function pascalizeKeys(obj: ObjectOrArray) {
   return transformKeys(obj, pascalize)
 }
 
-export function depascalizeKeys(obj: ObjectOrArray) {
+export function depascalizeKeys(obj: ObjectOrArray, sep?: string) {
   if (!isObjectOrArray(obj)) {
     return obj
   }
 
-  return transformKeys(obj, depascalize)
+  return transformKeys(obj, depascalize, sep)
 }
 
 export function camelizeKeysInPlace(obj: ObjectOrArray) {
@@ -273,12 +277,12 @@ export function camelizeKeysInPlace(obj: ObjectOrArray) {
   return transformKeysInPlace(obj, camelize)
 }
 
-export function decamelizeKeysInPlace(obj: ObjectOrArray) {
+export function decamelizeKeysInPlace(obj: ObjectOrArray, sep?: string) {
   if (!isObjectOrArray(obj)) {
     return obj
   }
 
-  return transformKeysInPlace(obj, decamelize)
+  return transformKeysInPlace(obj, decamelize, sep)
 }
 
 export function pascalizeKeysInPlace(obj: ObjectOrArray) {
@@ -289,10 +293,10 @@ export function pascalizeKeysInPlace(obj: ObjectOrArray) {
   return transformKeysInPlace(obj, pascalize)
 }
 
-export function depascalizeKeysInPlace(obj: ObjectOrArray) {
+export function depascalizeKeysInPlace(obj: ObjectOrArray, sep?: string) {
   if (!isObjectOrArray(obj)) {
     return obj
   }
 
-  return transformKeysInPlace(obj, depascalize)
+  return transformKeysInPlace(obj, depascalize, sep)
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,7 @@ export function camelize(str: string) {
   return String.fromCharCode.apply(undefined, transformed)
 }
 
-export function decamelize(str: string) {
+export function decamelize(str: string, sep?: string) {
   const firstChar = str.charCodeAt(0)
 
   if (!isLower(firstChar) || isNaN(firstChar)) {
@@ -79,13 +79,19 @@ export function decamelize(str: string) {
   let changed = false
   const transformed = [firstChar]
 
+  let separator = CHAR_UNDERSCORE
+
+  if(sep && sep.charCodeAt(0)) {
+    separator = sep.charCodeAt(0)
+  }
+
   const length = str.length
   for (let i = 1; i < length; i++) {
     const c = str.charCodeAt(i)
 
     if (isUpper(c)) {
       changed = true
-      transformed.push(CHAR_UNDERSCORE)
+      transformed.push(separator)
       transformed.push(toLower(c))
     } else {
       transformed.push(c)
@@ -138,7 +144,7 @@ export function pascalize(str: string) {
   return String.fromCharCode.apply(undefined, transformed)
 }
 
-export function depascalize(str: string) {
+export function depascalize(str: string, sep?: string) {
   const firstChar = str.charCodeAt(0)
 
   if (!isUpper(firstChar) || isNaN(firstChar)) {
@@ -147,12 +153,18 @@ export function depascalize(str: string) {
 
   const transformed = [toLower(firstChar)]
 
+  let separator = CHAR_UNDERSCORE
+
+  if(sep && sep.charCodeAt(0)) {
+    separator = sep.charCodeAt(0)
+  }
+
   const length = str.length
   for (let i = 1; i < length; i++) {
     const c = str.charCodeAt(i)
 
     if (isUpper(c)) {
-      transformed.push(CHAR_UNDERSCORE)
+      transformed.push(separator)
       transformed.push(toLower(c))
     } else {
       transformed.push(c)

--- a/test.js
+++ b/test.js
@@ -31,6 +31,10 @@ test('.decamelize :: converts camelcased strings to underscore', (t) => {
   t.is(fastCase.decamelize('theTestString'), 'the_test_string')
 })
 
+test('.decamelize :: converts camelcased strings to separator', (t) => {
+  t.is(fastCase.decamelize('theTestString', '-'), 'the-test-string')
+})
+
 test('.decamelize :: does not separate numbers', (t) => {
   t.is(fastCase.decamelize('theTestString123'), 'the_test_string123')
 })
@@ -67,6 +71,10 @@ test('.pascalize :: preserves numbers', (t) => {
 
 test('.depascalize :: converts pascalcase strings to underscore', (t) => {
   t.is(fastCase.depascalize('TheTestString'), 'the_test_string')
+})
+
+test('.depascalize :: converts pascalcase strings to separator', (t) => {
+  t.is(fastCase.depascalize('TheTestString', '-'), 'the-test-string')
 })
 
 test('.depascalize :: does not separate numbers', (t) => {

--- a/test.js
+++ b/test.js
@@ -156,6 +156,37 @@ test('.camelizeKeys :: does not convert functions', (t) => {
   t.deepEqual(fastCase.camelizeKeys({my_function: func}), {myFunction: func})
 })
 
+// .decamelizeKeys
+
+test('.decamelizeKeys :: decamelizes object keys', (t) => {
+  t.deepEqual(
+    fastCase.decamelizeKeys({
+      firstAttribute: 'foo',
+      secondAttribute: 'bar',
+    }),
+    {
+      first_attribute: 'foo',
+      second_attribute: 'bar',
+    },
+  )
+})
+
+test('.decamelizeKeys :: decamelizes object keys with custom separator', (t) => {
+  t.deepEqual(
+    fastCase.decamelizeKeys(
+      {
+        firstAttribute: 'foo',
+        secondAttribute: 'bar',
+      },
+      '-',
+    ),
+    {
+      'first-attribute': 'foo',
+      'second-attribute': 'bar',
+    },
+  )
+})
+
 // .pascalizeKeys
 
 test('.pascalizeKeys :: converts object keys to camelcase', (t) => {
@@ -224,4 +255,35 @@ test('.pascalizeKeys :: does not convert date objects', (t) => {
 test('.pascalizeKeys :: does not convert functions', (t) => {
   const func = function () {}
   t.deepEqual(fastCase.pascalizeKeys({my_function: func}), {MyFunction: func})
+})
+
+// .depascalizeKeys
+
+test('.depascalizeKeys :: decamelizes object keys', (t) => {
+  t.deepEqual(
+    fastCase.depascalizeKeys({
+      FirstAttribute: 'foo',
+      SecondAttribute: 'bar',
+    }),
+    {
+      first_attribute: 'foo',
+      second_attribute: 'bar',
+    },
+  )
+})
+
+test('.depascalizeKeys :: decamelizes object keys with custom separator', (t) => {
+  t.deepEqual(
+    fastCase.depascalizeKeys(
+      {
+        FirstAttribute: 'foo',
+        SecondAttribute: 'bar',
+      },
+      '-',
+    ),
+    {
+      'first-attribute': 'foo',
+      'second-attribute': 'bar',
+    },
+  )
 })


### PR DESCRIPTION
Implements #68.

Open to discuss, if `decamelizeKeys`, `decamelizeKeysInPlace`, `depascalizeKeys` and `depascalizeKeysInPlace` also should get the separator option. If so, how should it be implemented to hit performance the least? A wrapper for the callback which is handed to `transformKeys` would increase the call stack by one otherwise a parameter to `transformKeys` has to added which passes the separator to the callback.