### PR TITLE
Added new benchmark for ts-case-convert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.log
 
 .vscode/
+.idea/
 dist/
 node_modules/

--- a/benchmark.js
+++ b/benchmark.js
@@ -2,6 +2,9 @@ const Benchmark = require('benchmark')
 
 const humps = require('humps')
 const xcase = require('xcase')
+const tsCaseConvert = require('ts-case-convert')
+
+
 const fastCase = require('.')
 
 const objectBare = {
@@ -799,6 +802,9 @@ new Benchmark.Suite()
   .add('humps#camelize', function () {
     humps.camelize(getStringForCamelize())
   })
+  .add('ts-case-convert#camelize', function () {
+    tsCaseConvert.toCamel(getStringForCamelize())
+  })
   .on('cycle', onCycle)
   .on('complete', onComplete)
   .run()
@@ -827,6 +833,9 @@ new Benchmark.Suite()
   .add('humps#pascalize', function () {
     humps.pascalize(getStringForPascalize())
   })
+  .add('ts-case-convert#pascalize', function () {
+    tsCaseConvert.toPascal(getStringForPascalize())
+  })
   .on('cycle', onCycle)
   .on('complete', onComplete)
   .run()
@@ -854,6 +863,9 @@ new Benchmark.Suite()
   })
   .add('humps#camelizeKeys', function () {
     humps.camelizeKeys(smallObject)
+  })
+  .add('ts-case-convert#camelizeKeys', function () {
+    tsCaseConvert.objectToCamel(smallObject)
   })
   .on('cycle', onCycle)
   .on('complete', onComplete)
@@ -894,6 +906,9 @@ new Benchmark.Suite()
   .add('humps#camelizeKeys (large object)', function () {
     humps.camelizeKeys(objectPool.pop())
   })
+  .add('ts-case-convert#camelizeKeys (large object)', function () {
+    tsCaseConvert.objectToCamel(objectPool.pop())
+  })
   .on('cycle', onCycle)
   .on('complete', onComplete)
   .run()
@@ -919,6 +934,9 @@ new Benchmark.Suite()
   })
   .add('humps#pascalizeKeys (large object)', function () {
     humps.pascalizeKeys(camelizedObject)
+  })
+  .add('ts-case-convert#pascalizeKeys (large object)', function () {
+    tsCaseConvert.objectToPascal(camelizedObject)
   })
   .on('cycle', onCycle)
   .on('complete', onComplete)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "microbundle": "^0.15.0",
     "prettier": "^2.0.5",
     "typescript": "^4.0.2",
-    "xcase": "^2.0.1"
+    "xcase": "^2.0.1",
+    "ts-case-convert": "^2.0.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4225,6 +4225,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+ts-case-convert@^2.0.7:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/ts-case-convert/-/ts-case-convert-2.0.7.tgz#a92b9fb17aadde088f34329f6841cf5640c24f23"
+  integrity sha512-Kqj8wrkuduWsKUOUNRczrkdHCDt4ZNNd6HKjVw42EnMIGHQUABS4pqfy0acETVLwUTppc1fzo/yi11+uMTaqzw==
+
 tslib@^2.0.3, tslib@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"


### PR DESCRIPTION
My results of launching the benchmark:

```
xcase#camelize x 17,956,449 ops/sec ±0.60% (191 runs sampled)
fastCase#camelize x 16,718,339 ops/sec ±0.54% (191 runs sampled)
humps#camelize x 1,993,313 ops/sec ±1.19% (191 runs sampled)
ts-case-convert#camelize x 1,748,958 ops/sec ±0.36% (191 runs sampled)
Fastest is xcase#camelize

xcase#decamelize x 14,848,432 ops/sec ±0.45% (191 runs sampled)
fastCase#decamelize x 14,103,910 ops/sec ±0.89% (187 runs sampled)
humps#decamelize x 3,464,126 ops/sec ±0.51% (192 runs sampled)
Fastest is xcase#decamelize

xcase#pascalize x 16,667,220 ops/sec ±0.68% (191 runs sampled)
fastCase#pascalize x 15,533,738 ops/sec ±0.97% (183 runs sampled)
humps#pascalize x 1,763,553 ops/sec ±0.42% (190 runs sampled)
ts-case-convert#pascalize x 1,045,243 ops/sec ±0.68% (191 runs sampled)
Fastest is xcase#pascalize

xcase#depascalize x 13,496,102 ops/sec ±0.56% (187 runs sampled)
fastCase#depascalize x 13,611,794 ops/sec ±1.08% (189 runs sampled)
humps#depascalize x 3,316,026 ops/sec ±0.49% (190 runs sampled)
Fastest is fastCase#depascalize

xcase#camelizeKeys x 1,559,905 ops/sec ±0.57% (191 runs sampled)
fastCase#camelizeKeys x 1,500,794 ops/sec ±0.36% (191 runs sampled)
humps#camelizeKeys x 334,554 ops/sec ±0.48% (194 runs sampled)
ts-case-convert#camelizeKeys x 340,245 ops/sec ±0.44% (191 runs sampled)
Fastest is xcase#camelizeKeys

xcase#camelizeKeys (in place) x 1,848,366 ops/sec ±0.45% (190 runs sampled)
fastCase#camelizeKeysInPlace (in place) x 1,618,304 ops/sec ±0.44% (189 runs sampled)
Fastest is xcase#camelizeKeys (in place)

xcase#decamelizeKeys x 1,531,531 ops/sec ±0.73% (185 runs sampled)
fastCase#decamelizeKeys x 1,565,089 ops/sec ±0.73% (189 runs sampled)
humps#decamelizeKeys x 561,150 ops/sec ±0.45% (190 runs sampled)
Fastest is fastCase#decamelizeKeys

xcase#camelizeKeys (large object) x 1,545 ops/sec ±0.60% (188 runs sampled)
fastCase#camelizeKeys (large object) x 1,781 ops/sec ±0.47% (190 runs sampled)
humps#camelizeKeys (large object) x 429 ops/sec ±0.28% (186 runs sampled)
ts-case-convert#camelizeKeys (large object) x 459 ops/sec ±0.55% (185 runs sampled)
Fastest is fastCase#camelizeKeys (large object)

xcase#camelizeKeys (in place) (large object) x 1,345 ops/sec ±0.60% (189 runs sampled)
fastCase#camelizeKeysInPlace (in place) (large object) x 1,743 ops/sec ±0.98% (190 runs sampled)
Fastest is fastCase#camelizeKeysInPlace (in place) (large object)

xcase#pascalizeKeys (large object) x 1,066 ops/sec ±1.20% (190 runs sampled)
fastCase#pascalizeKeys (large object) x 1,271 ops/sec ±0.54% (190 runs sampled)
humps#pascalizeKeys (large object) x 517 ops/sec ±0.27% (189 runs sampled)
ts-case-convert#pascalizeKeys (large object) x 247 ops/sec ±0.38% (186 runs sampled)
Fastest is fastCase#pascalizeKeys (large object)

xcase#pascalizeKeys (in place) (large object) x 1,986 ops/sec ±1.62% (182 runs sampled)
fastCase#pascalizeKeysInPlace (in place) (large object) x 2,560 ops/sec ±1.16% (189 runs sampled)
Fastest is fastCase#pascalizeKeysInPlace (in place) (large object)
```